### PR TITLE
Also add "postcode + city" as city label

### DIFF
--- a/addok_france/utils.py
+++ b/addok_france/utils.py
@@ -154,6 +154,7 @@ def make_labels(helper, result):
         label = name
         if postcode and result.type == 'municipality':
             add(labels, '{} {}'.format(label, postcode))
+            add(labels, '{} {}'.format(postcode, label))
         add(labels, label)
         if city and city != label:
             add(labels, '{} {}'.format(label, city))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -322,5 +322,6 @@ def test_make_municipality_labels(config):
     make_labels(None, result)
     assert result.labels == [
         'Lille',
+        '59000 Lille',
         'Lille 59000',
     ]


### PR DESCRIPTION
Otherwise "59000 Lille" will only returns streets (while "Lille 59000" will return the expected city).

See also https://github.com/addok/addok-france/commit/3cb188391318c3ba7361792249641af703493421