### PR TITLE
Add more clean patterns from BAN data

### DIFF
--- a/addok_france/utils.py
+++ b/addok_france/utils.py
@@ -98,7 +98,13 @@ CLEAN_PATTERNS = (
     (" {2,}", " "),
     ("[ -]s/[ -]", " sur "),
     ("[ -]s/s[ -]", " sous "),
-    ("^lieux?[ -]?dits?\\b(?=.)", ""),
+    ("^lieux?[ -]?dits?\\b(?=.)", ""), # BAN 07/2022 : 68056
+    ("^ham(eau)?\\b(?=.)", ""), # BAN 07/2022 : 7449
+    ("^quartier\\b(?=.)", ""), # BAN 07/2022 : 4006
+    ("^ferme\\b(?=.)", ""), # BAN 07/2022 : 2969
+    ("^domaine\\b(?=.)", ""), # BAN 07/2022 : 2409
+    ("^village\\b(?=.)", ""), # BAN 07/2022 : 1947
+    ("^chemin rural(( n°?)? ?[0-9]+)?( dit)?\\b(?=.)", "chemin "), # BAN 07/2022 : 2060
 )
 CLEAN_COMPILED = list(
     (re.compile(pattern, flags=re.IGNORECASE), replacement)


### PR DESCRIPTION
BAN data contains "descriptive" prefix in the data. Variants of "Lieu-dit" are already removed. But there is more in BAN data. Remove most commons ones.

Also clean "chemin rural". This "name" are from cadastre and are not really in use on the ground.