### PR TITLE
Support for merged municipalities (communes nouvelles)

### DIFF
--- a/addok_france/utils.py
+++ b/addok_france/utils.py
@@ -196,12 +196,19 @@ def make_labels(helper, result):
     For addresses in merged municipalities (communes nouvelles), the city field
     can be a list containing all valid city names (historical and new).
     This allows addresses to be found using any of their valid city names.
+    
+    Labels are generated in priority order using insert(0), where the last-added
+    label appears first. This ordering is important for result scoring in addok.
     """
     if result.labels:
         return
     housenumber = getattr(result, "housenumber", None)
 
     def add(labels, label):
+        """
+        Add a label to the list, with insert(0) for priority ordering.
+        If housenumber is present, also adds the housenumber variant.
+        """
         labels.insert(0, label)
         if housenumber:
             label = "{} {}".format(housenumber, label)

--- a/addok_france/utils.py
+++ b/addok_france/utils.py
@@ -216,7 +216,11 @@ def make_labels(helper, result):
 
     # Support both single city (string) and merged municipalities (list)
     raw_city = result._rawattr("city")
-    cities = raw_city if isinstance(raw_city, list) else [raw_city]
+    # Normalize to list: if list, use as-is; if empty list, treat as [None]; if scalar, wrap in list
+    if isinstance(raw_city, list):
+        cities = raw_city if raw_city else [None]
+    else:
+        cities = [raw_city]
 
     postcode = result.postcode
     names = result._rawattr("name")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -367,6 +367,74 @@ def test_make_labels_merged_cities(config):
     assert any('CHEMILLE EN ANJOU' in label and 'ST GEORGES DES GARDES' not in label for label in result.labels)
 
 
+def test_make_labels_empty_city_list(config):
+    """Test that empty city list generates base labels without city."""
+    doc = {
+        "_id": "53543a313139353538390001",
+        "id": "53543a313139353538390001",
+        "type": "street",
+        "postcode": "75010",
+        "lat": "48.8566",
+        "lon": "2.3522",
+        "name": "RUE DE TEST",
+        "city": [],  # Empty list should be treated as None
+    }
+
+    process_documents(json.dumps(doc))
+    result = Result(get_document('d|53543a313139353538390001'))
+    make_labels(None, result)
+
+    # Should generate base labels without city
+    assert 'RUE DE TEST 75010' in result.labels or 'RUE DE TEST' in result.labels
+    # Should not be empty
+    assert len(result.labels) > 0
+
+
+def test_make_labels_city_none(config):
+    """Test that None city value generates base labels."""
+    doc = {
+        "_id": "53543a313139353538390002",
+        "id": "53543a313139353538390002",
+        "type": "street",
+        "postcode": "75011",
+        "lat": "48.8566",
+        "lon": "2.3522",
+        "name": "AVENUE EXEMPLE",
+        "city": None,
+    }
+
+    process_documents(json.dumps(doc))
+    result = Result(get_document('d|53543a313139353538390002'))
+    make_labels(None, result)
+
+    # Should generate base labels without city
+    assert any('AVENUE EXEMPLE' in label for label in result.labels)
+    assert len(result.labels) > 0
+
+
+def test_make_labels_single_city_string(config):
+    """Test that single city as string still works (backward compatibility)."""
+    doc = {
+        "_id": "53543a313139353538390003",
+        "id": "53543a313139353538390003",
+        "type": "street",
+        "postcode": "69001",
+        "lat": "45.7640",
+        "lon": "4.8357",
+        "name": "RUE DE LYON",
+        "city": "LYON",
+    }
+
+    process_documents(json.dumps(doc))
+    result = Result(get_document('d|53543a313139353538390003'))
+    make_labels(None, result)
+
+    # Should generate labels with city
+    assert any('LYON' in label for label in result.labels)
+    assert any('RUE DE LYON' in label for label in result.labels)
+    assert len(result.labels) > 0
+
+
 def test_make_municipality_labels(config):
     doc = {
         'id': 'xxxx',


### PR DESCRIPTION
This PR rebases and completes the work started in #13 by @aoudiamoncef.

### Context

In France, many municipalities have merged to form "communes nouvelles" (new municipalities). These merged municipalities often retain multiple official names to preserve the identity of the former communes.

### Changes

This PR enables `addok-france` to handle addresses with multiple city names by supporting `city` as a list in addition to the existing string format.

**Example:**
```python
{
    "name": "RUE PIERRE LEPOUREAU",
    "postcode": "49120",
    "city": [
        "ST GEORGES DES GARDES (CHEMILLE EN ANJOU)",
        "ST GEORGES DES GARDES",
        "CHEMILLE EN ANJOU"
    ]
}
```

This generates search labels for all three city variants, allowing users to find the address using any of the official names.

### Implementation

- **Minimal change approach**: Modified `make_labels()` to iterate over city names when provided as a list
- **Backward compatible**: Single city string continues to work exactly as before
- **Label priority preserved**: Maintains the original `insert(0)` pattern for proper search result scoring (addresses maintainer's concern from original PR)
- **Edge cases handled**: Empty lists and `None` values are treated consistently

### Testing

- ✅ All 106 existing tests pass
- ✅ Added test for merged municipalities with 3 city variants
- ✅ Added tests for edge cases (empty list, None, single string)
- **Total: 109 tests passing**

### Review comments addressed

The original PR #13 received feedback about using `set()` which would lose label priority ordering. This implementation preserves the exact original logic using `insert(0)`, ensuring labels maintain their intended priority for search scoring.

---

Closes #13 (rebased)
